### PR TITLE
Add online predictor badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
+[![Try MacTahminBotu Poisson Predictor on Socialistic](https://socialistic.ai/api/embed/shaped-skills-a9b43e?lang=en)](https://socialistic.ai/en/skill/shaped-skills-a9b43e?utm_source=github&utm_medium=readme&utm_campaign=20260622-worldcup-match-prediction-devs&utm_content=badge)
+
 predicts soccer match results using poisson regression, just for educational cutesy purposes. pls don't use it to bet on matches, it may upset you

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
 [![Try MacTahminBotu Poisson Predictor on Socialistic](https://socialistic.ai/api/embed/shaped-skills-a9b43e?lang=en)](https://socialistic.ai/en/skill/shaped-skills-a9b43e?utm_source=github&utm_medium=readme&utm_campaign=20260622-worldcup-match-prediction-devs&utm_content=badge)
 
 predicts soccer match results using poisson regression, just for educational cutesy purposes. pls don't use it to bet on matches, it may upset you
+
+[Try the Poisson predictor online](https://socialistic.ai/en/skill/shaped-skills-a9b43e?utm_source=github&utm_medium=readme&utm_campaign=20260622-worldcup-match-prediction-devs&utm_content=hyperlink) — upload a league CSV, pick two teams, get a scoreline. No setup needed.


### PR DESCRIPTION
## Summary

- Adds a clickable badge at the top of the README linking to a hosted version of the Poisson predictor on [socialistic.ai](https://socialistic.ai/en/skill/shaped-skills-a9b43e?utm_source=github&utm_medium=pr&utm_campaign=20260622-worldcup-match-prediction-devs&utm_content=hyperlink)
- Visitors can try the model directly — upload a CSV, pick two teams, get a scoreline — no clone or setup needed
- Badge includes UTM tracking so you can see how much traffic comes from the README

Resolves #4